### PR TITLE
Mark golangci-lint as required

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Zed extension for running [golangci-lint](https://golangci-lint.run/) on your Go code.
 
+## Requirements
+
+- [golangci-lint](https://golangci-lint.run/welcome/install/)
+
 ## Configuration
 
 ```json


### PR DESCRIPTION
The language server used by the extension requires golangci-lint to be
installed. Marking this requirement in README to reduce chance of
confusion during setup.